### PR TITLE
Add source directory creation on install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -45,6 +45,10 @@ class InstallCommand extends Command
             $this->createConsoleDirectory();
         }
 
+        if (! is_dir(base_path('tests/Browser/source'))) {
+            $this->createSourceDirectory();
+        }
+
         $stubs = [
             'ExampleTest.stub' => base_path('tests/Browser/ExampleTest.php'),
             'HomePage.stub' => base_path('tests/Browser/Pages/HomePage.php'),
@@ -99,6 +103,20 @@ class InstallCommand extends Command
         mkdir(base_path('tests/Browser/console'), 0755, true);
 
         file_put_contents(base_path('tests/Browser/console/.gitignore'), '*
+!.gitignore
+');
+    }
+
+    /**
+     * Create the source directory.
+     *
+     * @return void
+     */
+    protected function createSourceDirectory()
+    {
+        mkdir(base_path('tests/Browser/source'), 0755, true);
+
+        file_put_contents(base_path('tests/Browser/source/.gitignore'), '*
 !.gitignore
 ');
     }


### PR DESCRIPTION
If a browser step fails and the source code should be dumped, the source dir needs to be present, otherwise file_put_contents will throw an error since it cannot write to the destination. So the source dir should be created on install, just like the screenshot and console dirs are created on install.